### PR TITLE
Make padding and margins at courses page smaller

### DIFF
--- a/not-so-shit-lisam.user.css
+++ b/not-so-shit-lisam.user.css
@@ -22,3 +22,27 @@
         height: 0;
     }
 }
+
+@-moz-document url-prefix("https://www.student.ladok.se/student/#"){
+    /* This styling removes the unnecessary padding all over the place in the courses page.
+        Before this change only like 6 courses could fit the screen. Now you can see around 15 of them.*/
+    .card
+    {
+        padding: 0px 10px;
+        margin-bottom: 10px;       
+    }
+    .card-body
+    {
+        padding: 0;
+    }
+    
+    .card-body h4
+    {
+        margin: 0;
+    }
+    
+    .card-body p
+    {
+        margin: 0;
+    }
+}


### PR DESCRIPTION
This pull request is made to make the padding and margins at certain pages much smaller, making it possible to actually see an overview of your courses. 

If you want to see the new changes go to Lisam -> studieresultat -> log in -> current courses/completed courses. These lists will now be more compact. Before around 6 courses would fill the whole page, now it can fit around 15, maybe even up to 20. 

**NOTE** This might not be directly Lisam related since it is at "student.ladok.se" but it is still an annoyance with the new system.

I'm debating whether or not to remove the border around every card that exists, but decided to keep it in since it at least separates the courses.